### PR TITLE
Mark redash as an infra app

### DIFF
--- a/codefresh/CI/workflow.yml
+++ b/codefresh/CI/workflow.yml
@@ -132,6 +132,7 @@ steps:
             - REPO_NAME=${{CF_REPO_NAME}}
             - REVISION=${{CF_REVISION}}
             - BUILD_ID=${{CF_BUILD_ID}}
+            - APP_TYPE="infra"
             - CHECK_LOCK="false"
     when:
       condition:
@@ -157,6 +158,7 @@ steps:
             - REPO_NAME=${{CF_REPO_NAME}}
             - REVISION=${{CF_REVISION}}
             - BUILD_ID=${{CF_BUILD_ID}}
+            - APP_TYPE="infra"
             - CHECK_LOCK="false"
     when:
       condition:


### PR DESCRIPTION
- [x] **Please edit this and paste here your monday.com item url you are working on related to this PR.** :pray:
https://monday.monday.com/boards/4775886076/pulses/5021299783

Deploy step calls a pipeline defined [here](https://github.com/DaPulse/infra-core/tree/master/codefresh/argocd)
Since APP_TYPE is "business" by default, the pipeline will look for redash values in gitops in the business folder, although it is defined in "infra" folder.

